### PR TITLE
Fix closure issue in PII removal

### DIFF
--- a/backend/app/lm/handlers.py
+++ b/backend/app/lm/handlers.py
@@ -64,13 +64,13 @@ class ChatCompletionHandler(ABC, Generic[Req, Resp]):
             if config.pii_removal == "masking":
                 async with create_task_group() as tg:
                     for message in lm_request.content.messages:
-                        async def set_content():
+                        async def set_content(message=message):
                             message.content = await masking(message.content).evaluate(session=self.session)
                         tg.start_soon(set_content)
             if config.pii_removal == "replace":
                 async with create_task_group() as tg:
                     for message in lm_request.content.messages:
-                        async def set_content():
+                        async def set_content(message=message):
                             message.content, _ = await replace_masking(message.content).evaluate(session=self.session)
                         tg.start_soon(set_content)
             # Log the request event

--- a/backend/app/services/masking.py
+++ b/backend/app/services/masking.py
@@ -45,6 +45,7 @@ class Analyzer:
             response = await client.post(
                 url=f"{self.url}",
                 json=req.model_dump(exclude_none=True),
+                timeout=1000
             )
             try:
                 return analyzer_response.validate_python(response.raise_for_status().json())
@@ -131,6 +132,7 @@ class Anonymizer:
             response = await client.post(
                 url=f"{self.url}",
                 json=req.model_dump(exclude_none=True),
+                timeout=1000
             )
             try:
                 return AnonymizerResponse.model_validate(response.raise_for_status().json())


### PR DESCRIPTION
There was a bug when sending the tasks to the Analyser: when iterating over the messages python copied also the last reference and that was sent many times.